### PR TITLE
Reformatting annotations of ``Tasks``

### DIFF
--- a/src/test/java/org/terasology/tasks/persistence/TaskGraphTypeHandlerTest.java
+++ b/src/test/java/org/terasology/tasks/persistence/TaskGraphTypeHandlerTest.java
@@ -7,11 +7,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
-import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.persistence.typeHandling.gson.GsonPersistedData;
 import org.terasology.engine.persistence.typeHandling.gson.GsonPersistedDataSerializer;
 import org.terasology.engine.registry.In;
@@ -22,6 +18,7 @@ import org.terasology.tasks.GoToBeaconTask;
 import org.terasology.tasks.Task;
 import org.terasology.tasks.TaskGraph;
 import org.terasology.tasks.TimeConstraintTask;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import java.util.Collection;
 import java.util.Map;
@@ -30,9 +27,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(MTEExtension.class)
-@Dependencies("Tasks")
-@Tag("MteTest")
+@IntegrationEnvironment(dependencies = {"Tasks"})
 public class TaskGraphTypeHandlerTest {
     private static final GsonPersistedDataSerializer SERIALIZER = new GsonPersistedDataSerializer();
     private static final Gson GSON = new GsonBuilder().create();

--- a/src/test/java/org/terasology/tasks/persistence/TaskGraphTypeHandlerTest.java
+++ b/src/test/java/org/terasology/tasks/persistence/TaskGraphTypeHandlerTest.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@IntegrationEnvironment(dependencies = {"Tasks"})
+@IntegrationEnvironment(dependencies = "Tasks")
 public class TaskGraphTypeHandlerTest {
     private static final GsonPersistedDataSerializer SERIALIZER = new GsonPersistedDataSerializer();
     private static final Gson GSON = new GsonBuilder().create();


### PR DESCRIPTION
Related issue: [#5087](https://github.com/MovingBlocks/Terasology/issues/5087)

The goal of this PR is to replace old annotations in ``TaskGraphTypeHandlerTest``
