### PR TITLE
fix: Tasks do no longer get marked as failed after being marked as completed (fixes #30)

### DIFF
--- a/src/main/java/org/terasology/tasks/systems/TimedTaskSystem.java
+++ b/src/main/java/org/terasology/tasks/systems/TimedTaskSystem.java
@@ -50,8 +50,9 @@ public class TimedTaskSystem extends BaseComponentSystem implements UpdateSubscr
         Iterator<Entry<TimeConstraintTask, Quest>> it = questRefs.entrySet().iterator();
         while (it.hasNext()) {
             Entry<TimeConstraintTask, Quest> entry = it.next();
-            TaskGraph taskGraph = entry.getValue().getTaskGraph();
-            if (taskGraph.getDependencies(task).contains(entry.getKey())) {
+            Quest quest = entry.getValue();
+            TaskGraph taskGraph = quest.getTaskGraph();
+            if (quest.equals(event.getQuest()) || taskGraph.getDependencies(task).contains(entry.getKey())) {
                 it.remove();
             }
         }

--- a/src/main/java/org/terasology/tasks/systems/TimedTaskSystem.java
+++ b/src/main/java/org/terasology/tasks/systems/TimedTaskSystem.java
@@ -16,6 +16,7 @@ import org.terasology.tasks.Status;
 import org.terasology.tasks.Task;
 import org.terasology.tasks.TaskGraph;
 import org.terasology.tasks.TimeConstraintTask;
+import org.terasology.tasks.events.QuestCompleteEvent;
 import org.terasology.tasks.events.StartTaskEvent;
 import org.terasology.tasks.events.TaskCompletedEvent;
 
@@ -50,12 +51,16 @@ public class TimedTaskSystem extends BaseComponentSystem implements UpdateSubscr
         Iterator<Entry<TimeConstraintTask, Quest>> it = questRefs.entrySet().iterator();
         while (it.hasNext()) {
             Entry<TimeConstraintTask, Quest> entry = it.next();
-            Quest quest = entry.getValue();
-            TaskGraph taskGraph = quest.getTaskGraph();
-            if (quest.equals(event.getQuest()) || taskGraph.getDependencies(task).contains(entry.getKey())) {
+            TaskGraph taskGraph = entry.getValue().getTaskGraph();
+            if (taskGraph.getDependencies(task).contains(entry.getKey())) {
                 it.remove();
             }
         }
+    }
+
+    @ReceiveEvent
+    public void onQuestComplete(QuestCompleteEvent event, EntityRef entity) {
+        questRefs.values().removeIf(quest -> quest.equals(event.getQuest()));
     }
 
     @Override


### PR DESCRIPTION
The original problem was that sometimes a task that had already been completed would get marked as failed after some time
The problem in the code was that, when the quest was completed, some tasks of the quest would still have timers running, and if these timers ran out it would send a task failed event, making it so the quest would be marked as failed.
The proposed solution is that when a quest complete event is triggered, it removes the timers from every task that's part of that quest